### PR TITLE
Use request helper for cookie retrieval

### DIFF
--- a/src/EuCookieConsent.php
+++ b/src/EuCookieConsent.php
@@ -82,7 +82,7 @@ class EuCookieConsent
      */
     public static function getPopup($forced = false)
     {
-        if(!$forced && !empty($_COOKIE[config('eu-cookie-consent.cookie_name')])){
+        if(!$forced && !empty(request()->cookie(config('eu-cookie-consent.cookie_name')))){
             return '';
         }
 

--- a/tests/EuCookieConsentTest.php
+++ b/tests/EuCookieConsentTest.php
@@ -30,10 +30,22 @@ class EuCookieConsentTest extends TestCase
     }
 
     /** @test */
-    public function getPopup_returns_empty_string_if_cookie_is_not_set()
+    public function getHTML_returns_empty_string_if_cookie_is_not_set()
     {
         $html = EuCookieConsent::getHTML('header');
         $this->assertEmpty($html);
+    }
+
+    /**
+     * @test
+     */
+    public function getPopup_returns_empty_string_if_cookie_is_set()
+    {
+        $response = $this->call('POST', '/saveTheCookie', ['session'=>'1', 'xsrf-token'=>'1'], ['laravel_eu_cookie_consent'=>json_encode(['session'=>'1', 'xsrf-token'=>'1'])]);
+        $response->assertCookie('laravel_eu_cookie_consent', '{"session":"1","xsrf-token":"1"}', false);
+
+        $response = EuCookieConsent::getPopup();
+        $this->assertEquals('', $response);
     }
 
 


### PR DESCRIPTION
Based on my understanding, the super global $_COOKIE might not always be set, particularly if the server is running a caching engine like Swoole.

In such cases, the cookie can be retrieved using the request helper.